### PR TITLE
Enable automatic Postgres deployment

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -35,3 +35,10 @@ limits:
   maxPorts: 69
   maxBackups: 3
   maxDatabases: 3
+
+database:
+  host: localhost
+  port: 5432
+  user: postgres
+  password: postgres
+  name: niactyl

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ import express from 'express';
 import session from 'express-session';
 import passport from 'passport';
 import dotenv from 'dotenv';
+import { execSync } from 'child_process';
 import prisma from './utils/db.js';
 import config from './utils/config.js';
 
@@ -23,6 +24,13 @@ import { syncEggs } from './utils/syncEggs.js';
 import { syncLocations } from './utils/syncLocations.js';
 
 dotenv.config();
+
+// Automatically deploy Prisma schema on startup
+try {
+  execSync('npx prisma db push', { stdio: 'inherit' });
+} catch (err) {
+  console.error('❌ Prisma deploy failed:', err);
+}
 
 const app = express();
 app.use(express.json());

--- a/utils/config.js
+++ b/utils/config.js
@@ -4,4 +4,13 @@ import YAML from 'yaml';
 const file = fs.readFileSync('./config.yml', 'utf8');
 const config = YAML.parse(file);
 
+// If a database section is provided, build the DATABASE_URL automatically
+if (!process.env.DATABASE_URL && config.database) {
+  const { user, password, host = 'localhost', port = 5432, name } = config.database;
+  if (user && name) {
+    const cred = password ? `${encodeURIComponent(user)}:${encodeURIComponent(password)}` : encodeURIComponent(user);
+    process.env.DATABASE_URL = `postgresql://${cred}@${host}:${port}/${name}`;
+  }
+}
+
 export default config;

--- a/utils/db.js
+++ b/utils/db.js
@@ -1,5 +1,8 @@
 import { PrismaClient } from '@prisma/client';
+import './config.js'; // ensure DATABASE_URL is populated
 
-const prisma = new PrismaClient();
+const prisma = new PrismaClient({
+  datasources: { db: { url: process.env.DATABASE_URL } },
+});
 
 export default prisma;


### PR DESCRIPTION
## Summary
- wire up DATABASE_URL from `config.yml`
- use the custom DATABASE_URL in the Prisma client
- automatically run `prisma db push` when the server boots
- document database options in `config.yml`

## Testing
- `npm run build`
- `node server.js` *(fails: Can't reach database server at `localhost:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_68742b385e5c832bac33a533d427779a