### PR TITLE
Fix Prisma client import

### DIFF
--- a/utils/db.js
+++ b/utils/db.js
@@ -1,4 +1,5 @@
-import { PrismaClient } from '@prisma/client';
+import pkg from '@prisma/client';
+const { PrismaClient } = pkg;
 import './config.js'; // ensure DATABASE_URL is populated
 
 const prisma = new PrismaClient({


### PR DESCRIPTION
## Summary
- fix import statement for `@prisma/client`

## Testing
- `npm install`
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `node utils/db.js`

------
https://chatgpt.com/codex/tasks/task_e_68742f2f2b18832b95ff9ea536de30a1