### PR TITLE
Add plan selection step

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -22,6 +22,7 @@ plans:
       ports: 1
       backups: 0
       databases: 0
+    is24_7: false
     eggs: [1]
   basic:
     price: 50
@@ -32,6 +33,7 @@ plans:
       ports: 1
       backups: 1
       databases: 1
+    is24_7: true
     eggs: [1,2,3]
 
 database:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ const Login = React.lazy(() => import('./pages/Auth'));
 const Servers = React.lazy(() => import('./pages/Servers'));
 const Profile = React.lazy(() => import('./pages/Profile'));
 const CreateServer = React.lazy(() => import('./pages/CreateServer'));
+const ChoosePlan = React.lazy(() => import('./pages/ChoosePlan'));
 const Admin = React.lazy(() => import('./pages/Admin'));
 const Leaderboard = React.lazy(() => import('./pages/Leaderboard'));
 const Team = React.lazy(() => import('./pages/Team'));
@@ -81,6 +82,19 @@ function App() {
                 <Layout>
                   <Suspense fallback={null}>
                     <Servers />
+                  </Suspense>
+                </Layout>
+              </ProtectedRoute>
+            }
+          />
+
+          <Route
+            path="/servers/plans"
+            element={
+              <ProtectedRoute isAuthed={isAuthed}>
+                <Layout>
+                  <Suspense fallback={null}>
+                    <ChoosePlan />
                   </Suspense>
                 </Layout>
               </ProtectedRoute>

--- a/src/pages/ChoosePlan.tsx
+++ b/src/pages/ChoosePlan.tsx
@@ -1,0 +1,76 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { BRAND_COLOR } from '../config';
+
+interface Plan {
+  price: number;
+  resources: {
+    cpu: number;
+    memory: number;
+    disk: number;
+    ports: number;
+    backups: number;
+    databases: number;
+  };
+  eggs: number[];
+  is24_7?: boolean;
+}
+
+const ChoosePlan: React.FC = () => {
+  const [plans, setPlans] = useState<Record<string, Plan>>({});
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    fetch('/api/create-server/meta')
+      .then(res => res.json())
+      .then(data => setPlans(data.plans || {}));
+  }, []);
+
+  const selectPlan = (name: string) => {
+    navigate(`/servers/create?plan=${encodeURIComponent(name)}`);
+  };
+
+  return (
+    <>
+      <link
+        href="https://fonts.googleapis.com/css2?family=Rubik:wght@500;700&display=swap"
+        rel="stylesheet"
+      />
+      <style>{`:root { --brand-color: ${BRAND_COLOR}; }`}</style>
+
+      <div className="min-h-screen bg-[#0C0E14] px-6 py-10 text-white" style={{ fontFamily: 'Rubik, sans-serif' }}>
+        <h1 className="text-4xl font-bold text-center mb-2" style={{ color: 'var(--brand-color)' }}>
+          Choose a Plan
+        </h1>
+        <p className="text-center text-gray-400 mb-8 text-base">Select a plan for your new server.</p>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 max-w-3xl mx-auto">
+          {Object.entries(plans).map(([key, p]) => (
+            <div key={key} className="bg-[#14171F] p-6 rounded-2xl shadow space-y-3">
+              <h2 className="text-xl font-semibold">{key}</h2>
+              <p className="text-sm text-gray-400">{p.price} tokens</p>
+              <div className="text-sm text-gray-300 space-y-1">
+                <p><strong>vCPU:</strong> {p.resources.cpu}%</p>
+                <p><strong>RAM:</strong> {p.resources.memory} MB</p>
+                <p><strong>Disk:</strong> {p.resources.disk} MB</p>
+                <p><strong>Ports:</strong> {p.resources.ports}</p>
+                <p><strong>Databases:</strong> {p.resources.databases}</p>
+                <p><strong>Backups:</strong> {p.resources.backups}</p>
+                <p><strong>24/7:</strong> {p.is24_7 ? 'Yes' : 'No'}</p>
+              </div>
+              <button
+                onClick={() => selectPlan(key)}
+                className="w-full py-2 rounded-xl text-white"
+                style={{ backgroundColor: BRAND_COLOR }}
+              >
+                Select
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default ChoosePlan;

--- a/src/pages/CreateServer.tsx
+++ b/src/pages/CreateServer.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { BRAND_COLOR } from '../config';
 import Alert from '../components/Alert';
 
@@ -14,6 +14,7 @@ interface Plan {
     databases: number;
   };
   eggs: number[];
+  is24_7?: boolean;
 }
 
 const CreateServer = () => {
@@ -29,6 +30,7 @@ const CreateServer = () => {
   const [successPopup, setSuccessPopup] = useState<string | null>(null);
 
   const navigate = useNavigate();
+  const locationHook = useLocation();
 
   useEffect(() => {
     fetch('/api/create-server/meta')
@@ -37,10 +39,16 @@ const CreateServer = () => {
         setEggs(data.eggs || []);
         setLocations(data.locations || []);
         setPlans(data.plans || {});
-        const firstPlan = Object.keys(data.plans || {})[0];
-        if (firstPlan) setPlan(firstPlan);
+
+        const params = new URLSearchParams(locationHook.search);
+        const planParam = params.get('plan');
+        let initialPlan = planParam && data.plans[planParam] ? planParam : undefined;
+        if (!initialPlan) {
+          initialPlan = Object.keys(data.plans || {})[0];
+        }
+        if (initialPlan) setPlan(initialPlan);
       });
-  }, []);
+  }, [locationHook.search]);
 
   const filteredEggs = plans[plan]?.eggs || [];
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -94,7 +94,7 @@ const Dashboard: React.FC = () => {
 
         {/* Action Card */}
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 mb-8">
-          <ActionCard title="Create Server" desc="Ready to host? You can create a server here." to="/servers/create" label="Create Server" />
+          <ActionCard title="Create Server" desc="Ready to host? You can create a server here." to="/servers/plans" label="Create Server" />
         </div>
 
         {/* Server Table */}


### PR DESCRIPTION
## Summary
- add a new page to choose a plan when creating a server
- show plan details including 24/7 status
- link to new plan page from dashboard
- route `/servers/plans` in the app
- allow CreateServer to preselect plan from query string
- mark each plan in `config.yml` with `is24_7`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687522cd58ac832bb0cd18f620f5168a