### PR TITLE
Fix Pterodactyl user id fields

### DIFF
--- a/routes/pterodactyl/CreateServer.js
+++ b/routes/pterodactyl/CreateServer.js
@@ -94,7 +94,7 @@ router.post('/create', async (req, res) => {
     const { cpu, memory, disk, ports, backups, databases } = planToUse.resources;
     const payload = {
       name: name.substring(0, 48),
-      user: user.ptero_id,
+      user: user.id,
       egg: egg_id,
       docker_image: egg.docker_image,
       startup: egg.startup,

--- a/routes/pterodactyl/resetPassword.js
+++ b/routes/pterodactyl/resetPassword.js
@@ -38,9 +38,9 @@ router.post('/reset-password', async (req, res) => {
 
   try {
     const user = await prisma.user.findUnique({ where: { discord_id: req.user.discord.id } });
-    if (!user || !user.ptero_id) return res.status(404).json({ error: 'Pterodactyl user not found' });
+    if (!user) return res.status(404).json({ error: 'Pterodactyl user not found' });
 
-    const newPassword = await resetUserPassword(user.ptero_id);
+    const newPassword = await resetUserPassword(user.id);
     res.json({ newPassword });
   } catch (err) {
     console.error('❌ Failed to reset password:', err);

--- a/routes/pterodactyl/serverInfo.js
+++ b/routes/pterodactyl/serverInfo.js
@@ -6,7 +6,7 @@ const router = express.Router();
 router.get('/', async (req, res) => {
   if (!req.user) return res.status(401).json({ error: 'Unauthorized' });
 
-  const pteroId = req.user.ptero.ptero_id;
+  const pteroId = req.user.ptero.id;
   const servers = await prisma.server.findMany({ where: { user_id: pteroId } });
 
   res.json(servers);


### PR DESCRIPTION
## Summary
- use `user.id` for Pterodactyl server creation and password resets
- fix serverInfo route to use correct id

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687525b46314832b99307749cad997d8