### PR TITLE
Fix VPN check for ip-api

### DIFF
--- a/utils/security.js
+++ b/utils/security.js
@@ -16,9 +16,14 @@ export function getAccountAgeDays(discordId) {
 
 export async function isVpn(ip) {
   if (!ip) return false;
+  let cleanIp = ip;
+  if (cleanIp.startsWith('::ffff:')) {
+    cleanIp = cleanIp.substring(7);
+  }
+
   try {
     const { data } = await axios.get(
-      `http://ip-api.com/json/${ip}?fields=status,proxy,hosting`
+      `http://ip-api.com/json/${cleanIp}?fields=status,proxy,hosting`
     );
     return data.status === 'success' && (data.proxy || data.hosting);
   } catch (err) {


### PR DESCRIPTION
## Summary
- normalize IPv4-mapped IPv6 addresses before querying ip-api

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68756a3ae630832b9db98f0a23efe9d7