### PR TITLE
Fix prisma schema truncation

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -91,3 +91,10 @@ model TeamMember {
   @@unique([team_id, user_id])
   @@map("team_members")
 
+}
+
+model Blacklist {
+  id         Int     @id @default(autoincrement())
+  discord_id String? @unique
+  ip         String? @unique
+}


### PR DESCRIPTION
## Summary
- close `TeamMember` model in schema
- restore `Blacklist` model

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68756cd68db0832b9fdb49c79df1fe60