### PR TITLE
Use URLs from config files

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,5 +1,12 @@
 sessionSecret: "change-this-to-a-very-random-string"
 
+server:
+  url: "http://localhost:3000"
+  port: 3000
+
+frontend:
+  url: "http://localhost:5173"
+
 discord:
   clientId: "1221092853531414660"
   clientSecret: "8zivFUfCMpvQQ0PWHw1tURSCeGJkvCFz"

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -94,7 +94,8 @@ router.get('/discord/callback',
     session: true,
   }),
   (req, res) => {
-    const redirectTo = `${process.env.FRONTEND_URL || 'http://localhost:5173'}/dashboard`;
+    const frontend = process.env.FRONTEND_URL || config.frontend.url || 'http://localhost:5173';
+    const redirectTo = `${frontend.replace(/\/$/, '')}/dashboard`;
     res.redirect(redirectTo);
   }
 );

--- a/server.js
+++ b/server.js
@@ -88,5 +88,6 @@ app.get('/api/me', async (req, res) => {
   }
 })();
 
-const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => console.log(`🚀 Server running on http://localhost:${PORT}`));
+const PORT = process.env.PORT || config.server.port || 3000;
+const baseUrl = config.server.url?.replace(/\/$/, '') || `http://localhost:${PORT}`;
+app.listen(PORT, () => console.log(`🚀 Server running on ${baseUrl}`));

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,3 +4,7 @@ export const DISCORD_COLOR = '#5865F2';
 export const TOS_URL = 'https://firecone.eu/terms';
 export const PANEL_URL = 'https://panel.firecone.eu';
 
+const env = typeof import.meta !== 'undefined' ? (import.meta as any).env : process.env;
+export const API_BASE_URL = env?.VITE_API_BASE_URL || 'http://localhost:3000';
+export const FRONTEND_URL = env?.VITE_FRONTEND_URL || 'http://localhost:5173';
+

--- a/utils/config.js
+++ b/utils/config.js
@@ -4,6 +4,23 @@ import YAML from 'yaml';
 const file = fs.readFileSync('./config.yml', 'utf8');
 const config = YAML.parse(file);
 
+// Provide sensible defaults for server and frontend URLs
+config.server = config.server || { url: 'http://localhost:3000', port: 3000 };
+config.frontend = config.frontend || { url: 'http://localhost:5173' };
+
+// Expose URLs/ports as env vars for convenience
+if (!process.env.PORT && config.server.port) {
+  process.env.PORT = config.server.port;
+}
+if (!process.env.FRONTEND_URL && config.frontend.url) {
+  process.env.FRONTEND_URL = config.frontend.url;
+}
+
+// Build Discord callback URL from server.url if not explicitly set
+if (!config.discord.callbackUrl && config.server.url) {
+  config.discord.callbackUrl = `${config.server.url}/api/auth/discord/callback`;
+}
+
 // If a database section is provided, build the DATABASE_URL automatically
 if (!process.env.DATABASE_URL && config.database) {
   const { user, password, host = 'localhost', port = 5432, name } = config.database;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,14 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
+import { API_BASE_URL } from './src/config';
 
 export default defineConfig({
   plugins: [react()],
   root: './src',
   server: {
     proxy: {
-      '/api': 'http://localhost:3000'
+      '/api': API_BASE_URL
     }
   },
   build: {


### PR DESCRIPTION
## Summary
- load server and frontend URLs from `config.yml`
- set API URL constants in `src/config.ts`
- rely on config for auth redirects and Vite proxy
- show server URL when starting server

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68765012490c832b9510c22df7ba4cf8