### PR TITLE
Enhance startup automation

### DIFF
--- a/server.js
+++ b/server.js
@@ -5,6 +5,10 @@ import { execSync } from 'child_process';
 import prisma from './utils/db.js';
 import config from './utils/config.js'; // Loads sessionSecret from YAML
 
+// Clean startup output and show an initialization message
+console.clear();
+console.log('🟢 Initializing Niactyl server...');
+
 import './routes/auth.js'; // Initializes passport strategy
 
 // Route Imports
@@ -22,9 +26,11 @@ import teamRoutes from './routes/api/Teams.js';
 import { syncEggs } from './utils/syncEggs.js';
 import { syncLocations } from './utils/syncLocations.js';
 
-// Automatically deploy Prisma schema on startup
+// Automatically generate Prisma client and deploy schema on startup
 try {
+  execSync('npx prisma generate', { stdio: 'inherit' });
   execSync('npx prisma db push', { stdio: 'inherit' });
+  console.log('✅ Prisma schema deployed');
 } catch (err) {
   console.error('❌ Prisma deploy failed:', err);
 }
@@ -90,4 +96,7 @@ app.get('/api/me', async (req, res) => {
 
 const PORT = process.env.PORT || config.server.port || 3000;
 const baseUrl = config.server.url?.replace(/\/$/, '') || `http://localhost:${PORT}`;
-app.listen(PORT, () => console.log(`🚀 Server running on ${baseUrl}`));
+app.listen(PORT, () => {
+  console.log(`🚀 Server running on ${baseUrl}`);
+  console.log('✅ Startup complete');
+});


### PR DESCRIPTION
## Summary
- clear the console on boot and print a startup message
- automatically run `prisma generate` before `prisma db push`
- log an additional message once the server is running

## Testing
- `npm start` *(fails: Can't reach database server or external API)*

------
https://chatgpt.com/codex/tasks/task_e_6877712b940c832bad5aa2f0bb7772a0