### PR TITLE
Simplify startup logging

### DIFF
--- a/server.js
+++ b/server.js
@@ -5,6 +5,10 @@ import { execSync } from 'child_process';
 import prisma from './utils/db.js';
 import config from './utils/config.js'; // Loads sessionSecret from YAML
 
+// Clean startup output and show an initialization message
+console.clear();
+console.log('🟢 Initializing Niactyl server...');
+
 import './routes/auth.js'; // Initializes passport strategy
 
 // Route Imports
@@ -22,9 +26,11 @@ import teamRoutes from './routes/api/Teams.js';
 import { syncEggs } from './utils/syncEggs.js';
 import { syncLocations } from './utils/syncLocations.js';
 
-// Automatically deploy Prisma schema on startup
+// Automatically generate Prisma client and deploy schema on startup
 try {
-  execSync('npx prisma db push', { stdio: 'inherit' });
+  execSync('npx prisma generate', { stdio: 'pipe' });
+  execSync('npx prisma db push', { stdio: 'pipe' });
+  console.log('✅ Prisma schema synced');
 } catch (err) {
   console.error('❌ Prisma deploy failed:', err);
 }
@@ -80,9 +86,10 @@ app.get('/api/me', async (req, res) => {
 // ✅ Sync eggs & locations on startup
 (async () => {
   try {
-    await syncLocations();
-    await syncEggs();
-    console.log('✅ Eggs and locations synced');
+    console.log('🔄 Syncing eggs and locations...');
+    const locationCount = await syncLocations();
+    const eggCount = await syncEggs();
+    console.log(`✅ Synced ${eggCount} eggs and ${locationCount} locations`);
   } catch (err) {
     console.error('❌ Error syncing eggs or locations:', err);
   }
@@ -90,4 +97,7 @@ app.get('/api/me', async (req, res) => {
 
 const PORT = process.env.PORT || config.server.port || 3000;
 const baseUrl = config.server.url?.replace(/\/$/, '') || `http://localhost:${PORT}`;
-app.listen(PORT, () => console.log(`🚀 Server running on ${baseUrl}`));
+app.listen(PORT, () => {
+  console.log(`🚀 Server running on ${baseUrl}`);
+  console.log('✅ Startup complete');
+});

--- a/utils/syncEggs.js
+++ b/utils/syncEggs.js
@@ -13,8 +13,6 @@ const api = axios.create({
 
 export async function syncEggs() {
   try {
-    console.log('🥚 Syncing eggs...');
-
     const allowedNestId = config.pterodactyl.allowedNestId;
     if (!allowedNestId) throw new Error('No allowedNestId set in config.yml');
 
@@ -39,8 +37,10 @@ export async function syncEggs() {
 
     await prisma.egg.deleteMany();
     await prisma.egg.createMany({ data: eggs });
-    console.log(`✅ Synced ${eggs.length} eggs with environment variables`);
+
+    return eggs.length;
   } catch (err) {
     console.error('❌ Failed to sync eggs:', err.response?.data || err.message);
+    throw err;
   }
 }

--- a/utils/syncLocations.js
+++ b/utils/syncLocations.js
@@ -13,7 +13,6 @@ const api = axios.create({
 
 export async function syncLocations() {
   try {
-    console.log('📦 Syncing locations...');
     const res = await api.get('/locations');
 
     const locations = res.data.data.map(loc => ({
@@ -23,8 +22,10 @@ export async function syncLocations() {
 
     await prisma.location.deleteMany();
     await prisma.location.createMany({ data: locations });
-    console.log(`✅ Synced ${locations.length} locations`);
+
+    return locations.length;
   } catch (err) {
     console.error('❌ Failed to sync locations:', err.response?.data || err.message);
+    throw err;
   }
 }


### PR DESCRIPTION
## Summary
- suppress Node deprecation warnings in npm scripts
- hide verbose output when generating and deploying Prisma
- return counts from the sync helpers
- show a single sync summary message during startup

## Testing
- `npm install`
- `npm start` *(fails: Can't reach database server or external API)*

------
https://chatgpt.com/codex/tasks/task_e_6877712b940c832bad5aa2f0bb7772a0