### PR TITLE
Improve server management UX

### DIFF
--- a/routes/pterodactyl/serverInfo.js
+++ b/routes/pterodactyl/serverInfo.js
@@ -12,6 +12,22 @@ router.get('/', async (req, res) => {
   res.json(servers);
 });
 
+router.get('/:id', async (req, res) => {
+  if (!req.user) return res.status(401).json({ error: 'Unauthorized' });
+
+  const serverId = Number(req.params.id);
+  if (isNaN(serverId)) return res.status(400).json({ error: 'Invalid id' });
+
+  const pteroId = req.user.ptero.id;
+  const server = await prisma.server.findFirst({
+    where: { id: serverId, user_id: pteroId }
+  });
+
+  if (!server) return res.status(404).json({ error: 'Server not found' });
+
+  res.json(server);
+});
+
 router.get('/meta', async (req, res) => {
   const eggs = await prisma.egg.findMany();
   const locations = await prisma.location.findMany();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ const ChoosePlan = React.lazy(() => import('./pages/ChoosePlan'));
 const Admin = React.lazy(() => import('./pages/Admin'));
 const Leaderboard = React.lazy(() => import('./pages/Leaderboard'));
 const Team = React.lazy(() => import('./pages/Team'));
+const EditServer = React.lazy(() => import('./pages/EditServer'));
 
 // Global dashboard data context
 export const AppContext = createContext<any>(null);
@@ -108,6 +109,19 @@ function App() {
                 <Layout>
                   <Suspense fallback={null}>
                     <CreateServer />
+                  </Suspense>
+                </Layout>
+              </ProtectedRoute>
+            }
+          />
+
+          <Route
+            path="/servers/edit/:id"
+            element={
+              <ProtectedRoute isAuthed={isAuthed}>
+                <Layout>
+                  <Suspense fallback={null}>
+                    <EditServer />
                   </Suspense>
                 </Layout>
               </ProtectedRoute>

--- a/src/pages/EditServer.tsx
+++ b/src/pages/EditServer.tsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import Alert from '../components/Alert';
+import { BRAND_COLOR } from '../config';
+
+interface Plan {
+  price: number;
+  resources: {
+    cpu: number;
+    memory: number;
+    disk: number;
+    ports: number;
+    backups: number;
+    databases: number;
+  };
+}
+
+const EditServer: React.FC = () => {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [plans, setPlans] = useState<Record<string, Plan>>({});
+  const [serverPlan, setServerPlan] = useState('');
+  const [alert, setAlert] = useState<{ type: 'success' | 'error'; msg: string } | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    fetch('/api/servers/meta')
+      .then(res => res.json())
+      .then(data => setPlans(data.plans || {}));
+
+    fetch(`/api/servers/${id}`, { credentials: 'include' })
+      .then(res => res.json())
+      .then(data => {
+        setServerPlan(data.plan || '');
+      });
+  }, [id]);
+
+  const handleSave = async () => {
+    if (!id) return;
+    const res = await fetch(`/api/servers/${id}/edit-plan`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ plan: serverPlan })
+    });
+    const data = await res.json();
+    if (res.ok) {
+      setAlert({ type: 'success', msg: '✅ Plan updated!' });
+      setTimeout(() => navigate('/servers', { replace: true }), 1000);
+    } else {
+      setAlert({ type: 'error', msg: `❌ ${data.error || 'Failed to update plan'}` });
+    }
+  };
+
+  return (
+    <>
+      <link href="https://fonts.googleapis.com/css2?family=Rubik:wght@500;700&display=swap" rel="stylesheet" />
+      <style>{`:root { --brand-color: ${BRAND_COLOR}; }`}</style>
+      <div className="min-h-screen bg-[#0C0E14] px-6 py-10 text-white" style={{ fontFamily: 'Rubik, sans-serif' }}>
+        <h1 className="text-3xl font-bold mb-6" style={{ color: 'var(--brand-color)' }}>Edit Plan</h1>
+        {alert && <Alert type={alert.type} message={alert.msg} />}
+        <div className="card space-y-6 max-w-md">
+          <div>
+            <label className="block mb-1 text-sm text-gray-400">Plan</label>
+            <select value={serverPlan} onChange={e => setServerPlan(e.target.value)}
+              className="w-full bg-[#1E212B] text-white p-2 rounded-xl border border-transparent focus:border-[var(--brand-color)]">
+              {Object.entries(plans).map(([key]) => (
+                <option key={key} value={key}>{key}</option>
+              ))}
+            </select>
+          </div>
+          <button onClick={handleSave} className="btn btn-brand w-full py-2 font-semibold">Save</button>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default EditServer;

--- a/src/pages/Servers.tsx
+++ b/src/pages/Servers.tsx
@@ -14,6 +14,8 @@ interface Server {
   ports: any[];
   databases: any[];
   backups: any[];
+  expires_at?: string;
+  plan?: string;
 }
 
 const Servers: React.FC = () => {
@@ -23,12 +25,19 @@ const Servers: React.FC = () => {
   const [confirmName, setConfirmName] = useState('');
   const [alertMessage, setAlertMessage] = useState('');
   const [alertType, setAlertType] = useState<'success' | 'error'>('success');
+  const [loadError, setLoadError] = useState('');
 
   useEffect(() => {
     fetch('/api/servers', { credentials: 'include' })
-      .then(res => res.json())
+      .then(res => {
+        if (!res.ok) throw new Error('Failed to load');
+        return res.json();
+      })
       .then(data => setServers(data))
-      .catch(err => console.error('Failed to load servers:', err));
+      .catch(err => {
+        console.error('Failed to load servers:', err);
+        setLoadError('Failed to load servers.');
+      });
   }, []);
 
   const confirmDelete = (id: number, name: string) => {
@@ -80,6 +89,10 @@ const Servers: React.FC = () => {
         <p className="text-center text-gray-400 mb-8 text-base">
           View and manage all the servers you've created.
         </p>
+        {loadError && <Alert type="error" message={loadError} />}
+        <p className="text-center text-sm text-gray-400 mb-6">
+          Ensure you have enough tokens when your server renews or it will be downgraded to the free plan.
+        </p>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 max-w-6xl mx-auto">
           {servers.map(server => (
@@ -95,6 +108,12 @@ const Servers: React.FC = () => {
                 <p><strong>Ports:</strong> {server.ports?.length || 0}</p>
                 <p><strong>Databases:</strong> {server.databases?.length || 0}</p>
                 <p><strong>Backups:</strong> {server.backups?.length || 0}</p>
+                {server.expires_at && (
+                  <p>
+                    <strong>Renews:</strong>{' '}
+                    {new Date(server.expires_at).toLocaleString()}
+                  </p>
+                )}
               </div>
 
               <div className="flex flex-wrap gap-3 mt-5">


### PR DESCRIPTION
## Summary
- expose GET `/api/servers/:id` for fetching one server
- add `EditServer` page and route for editing a server's plan
- show server renewal date and token warning on server list
- handle server list loading errors

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6878d693ecdc832b9bd332ca78790455