### PR TITLE
Unify brand gradient styling

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 import { Link, useNavigate, useLocation } from "react-router-dom";
 import { APP_NAME, BRAND_COLOR, PANEL_URL } from "../config";
+import { lightenColor } from "../utils/color";
 
 function Layout({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<any>(null);
@@ -72,7 +73,12 @@ function Layout({ children }: { children: React.ReactNode }) {
         href="https://fonts.googleapis.com/css2?family=Rubik:wght@500;700&display=swap"
         rel="stylesheet"
       />
-      <style>{`:root { --brand-color: ${BRAND_COLOR}; }`}</style>
+      <style>{`
+        :root {
+          --brand-color: ${BRAND_COLOR};
+          --brand-color-light: ${lightenColor(BRAND_COLOR, 20)};
+        }
+      `}</style>
 
       <div
         className="flex flex-col md:flex-row min-h-screen bg-[#0C0E14] text-white select-none"

--- a/src/index.css
+++ b/src/index.css
@@ -6,7 +6,7 @@
 /* Custom CSS Variables */
 :root {
   --brand-color: #fc6b05;
-  --brand-color-light: #ff8a3d;
+  --brand-color-light: #ff9e38;
   --background-color: #0c0e14;
   --background-color-dark: #090b11;
   --surface-color: #14171f;

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { APP_NAME, BRAND_COLOR, TOS_URL, DISCORD_COLOR } from '../config';
+import { lightenColor } from '../utils/color';
 
 const CURRENT_YEAR = new Date().getFullYear();
 
@@ -23,6 +24,12 @@ function Login() {
         href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Rubik:wght@500;700&display=swap"
         rel="stylesheet"
       />
+      <style>{`
+        :root {
+          --brand-color: ${BRAND_COLOR};
+          --brand-color-light: ${lightenColor(BRAND_COLOR, 20)};
+        }
+      `}</style>
 
       <div className="min-h-screen bg-[#0C0E14] flex flex-col items-center justify-center px-4 font-[Inter]">
         <div className="card text-center p-10 w-full max-w-md">

--- a/src/pages/CreateServer.tsx
+++ b/src/pages/CreateServer.tsx
@@ -94,7 +94,6 @@ const CreateServer = () => {
         href="https://fonts.googleapis.com/css2?family=Rubik:wght@500;700&display=swap"
         rel="stylesheet"
       />
-      <style>{`:root { --brand-color: ${BRAND_COLOR}; }`}</style>
 
       {successPopup && (
         <div className="fixed top-6 right-6 z-50">

--- a/src/pages/EditServer.tsx
+++ b/src/pages/EditServer.tsx
@@ -55,7 +55,6 @@ const EditServer: React.FC = () => {
   return (
     <>
       <link href="https://fonts.googleapis.com/css2?family=Rubik:wght@500;700&display=swap" rel="stylesheet" />
-      <style>{`:root { --brand-color: ${BRAND_COLOR}; }`}</style>
       <div className="min-h-screen bg-[#0C0E14] px-6 py-10 text-white" style={{ fontFamily: 'Rubik, sans-serif' }}>
         <h1 className="text-3xl font-bold mb-6" style={{ color: 'var(--brand-color)' }}>Edit Plan</h1>
         {alert && <Alert type={alert.type} message={alert.msg} />}

--- a/src/pages/Leaderboard.tsx
+++ b/src/pages/Leaderboard.tsx
@@ -22,11 +22,6 @@ const Leaderboard: React.FC = () => {
         href="https://fonts.googleapis.com/css2?family=Rubik:wght@500;700&display=swap"
         rel="stylesheet"
       />
-      <style>{`
-        :root {
-          --brand-color: ${BRAND_COLOR};
-        }
-      `}</style>
 
       <div className="min-h-screen bg-[#0C0E14] px-6 py-10 text-white" style={{ fontFamily: 'Rubik, sans-serif' }}>
         <h1 className="text-4xl font-bold text-center mb-2" style={{ color: 'var(--brand-color)' }}>

--- a/src/pages/Servers.tsx
+++ b/src/pages/Servers.tsx
@@ -89,7 +89,6 @@ const Servers: React.FC = () => {
         href="https://fonts.googleapis.com/css2?family=Rubik:wght@500;700&display=swap"
         rel="stylesheet"
       />
-      <style>{`:root { --brand-color: ${BRAND_COLOR}; }`}</style>
 
       <div className="min-h-screen bg-[#0C0E14] px-6 py-10 text-white" style={{ fontFamily: 'Rubik, sans-serif' }}>
         {alertMessage && <Alert type={alertType} message={alertMessage} />}

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -1,0 +1,10 @@
+export function lightenColor(color: string, percent: number): string {
+  const num = parseInt(color.replace('#', ''), 16);
+  let r = (num >> 16) + Math.round(2.55 * percent);
+  let g = ((num >> 8) & 0x00ff) + Math.round(2.55 * percent);
+  let b = (num & 0x0000ff) + Math.round(2.55 * percent);
+  r = r < 255 ? (r < 0 ? 0 : r) : 255;
+  g = g < 255 ? (g < 0 ? 0 : g) : 255;
+  b = b < 255 ? (b < 0 ? 0 : b) : 255;
+  return '#' + ((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1);
+}


### PR DESCRIPTION
## Summary
- compute lighter brand color on the fly
- inject brand color variables globally via `Layout` and `Auth`
- remove per-page brand color injections
- update default brand gradient values
- add utility to lighten colors

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6878fedd32a0832b8c2981d4468ac2f5